### PR TITLE
fixes for the databank update script

### DIFF
--- a/update_databanks.bash
+++ b/update_databanks.bash
@@ -9,5 +9,5 @@ done
 if ! [ -d blast ] ; then mkdir blast; fi
 cd blast
 /usr/bin/wget -N ftp://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz
-/bin/gunzip uniprot_sprot.fasta.gz
+/bin/gunzip -f uniprot_sprot.fasta.gz
 /usr/bin/makeblastdb -in uniprot_sprot.fasta -out sprot -dbtype prot -parse_seqids


### PR DESCRIPTION
* make sure that gunzip and tar always work during an update, not just the first time
* download files only if the server has a newer version.